### PR TITLE
fixed test for travis compatibility and added travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,24 @@
+language: python
+
+python:
+  - "3.4"
+  - "3.3"
+  - "3.2"
+  - "pypy3"
+
+before_install:
+  - sudo apt-get -qq update
+  - sudo apt-get install -qq git-core build-essential autoconf libtool
+  - sudo apt-get install libffi-dev
+  - curl -L https://github.com/libuv/libuv/archive/v1.2.1.tar.gz | tar xzf -
+  - (cd libuv-1.2.1 && ./autogen.sh && ./configure --prefix=/usr && make && sudo make install)
+
+install:
+  - pip install -r requirements.txt
+
+script:
+  - cd tests
+  - py.test
+
+notifications:
+  email: false

--- a/tests/test_greenio.py
+++ b/tests/test_greenio.py
@@ -135,15 +135,14 @@ class TestGreenSocketModule:
         assert sock
 
     def test_create_connection_timeout_error(self, fail_addr):
+        # Inspired by eventlet Greenio_test
         try:
             socket_patched.create_connection(fail_addr, timeout=0.01)
+            pytest.fail('Timeout not raised')
         except socket.timeout as e:
             assert str(e) == 'timed out'
-
-        if pyversion >= (3, 3):
-            # on python 3.3+, socket.timeout is an alias for OSError
-            try:
-                socket_patched.create_connection(fail_addr, timeout=0.01)
-            except OSError as e:
-                assert str(e) == 'timed out'
+        except socket.error as e:
+            # unreachable is also a valid outcome
+            if not get_errno(e) in (errno.EHOSTUNREACH, errno.ENETUNREACH):
+                raise
 


### PR DESCRIPTION
Closes #15 

Check https://travis-ci.org/Ecno92/guv for more info.
I had to change the test a little since the endpoint did not always result in a proper timeout. 
The changes in the tests are inspired by the test in the eventlet project: https://github.com/eventlet/eventlet/blob/master/tests/greenio_test.py

After merging the changes you can easily enable travis by logging into https://travis-ci.org/ with your Github account, followed by enabeling the webhook switch for the guv project. (http://docs.travis-ci.com/user/getting-started/)