### PR TITLE
Requests failing to download a file

### DIFF
--- a/guv/greenio.py
+++ b/guv/greenio.py
@@ -48,7 +48,7 @@ class socket(_socket.socket):
         that the operation we were waiting on was associated with a filehandle that's since been
         invalidated.
         """
-        if self._closed:
+        if self._closed and self._io_refs <= 0:
             # If we did any logging, alerting to a second trampoline attempt on a closed
             # socket here would be useful.
             raise IOClosed()


### PR DESCRIPTION
The following code fails to download the image from that server. If you disable guv, it works.

``` python
import guv; guv.monkey_patch() # comment this line and it will work
import requests

url = 'http://www.giantitp.com/comics/images/oots0001.gif'
r = requests.get(url, stream=True)
with open('file.gif', 'wb') as f:
    for chunk in r.iter_content(chunk_size=1024*4):
        if chunk:
            f.write(chunk)
```

It fails with the following message:

```
Traceback (most recent call last):
  File "/usr/lib/python3.5/socket.py", line 571, in readinto
    return self._sock.recv_into(b)
  File "/home/lucas/tmp/venv/lib/python3.5/site-packages/guv/greenio.py", line 200, in recv_into
    timeout_exc=s_timeout("timed out"))
  File "/home/lucas/tmp/venv/lib/python3.5/site-packages/guv/greenio.py", line 54, in _trampoline
    raise IOClosed()
guv.exceptions.IOClosed

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "min.py", line 7, in <module>
    for chunk in r.iter_content(chunk_size=1024*4):
  File "/home/lucas/tmp/venv/lib/python3.5/site-packages/requests/models.py", line 660, in generate
    for chunk in self.raw.stream(chunk_size, decode_content=True):
  File "/home/lucas/tmp/venv/lib/python3.5/site-packages/requests/packages/urllib3/response.py", line 344, in stream
    data = self.read(amt=amt, decode_content=decode_content)
  File "/home/lucas/tmp/venv/lib/python3.5/site-packages/requests/packages/urllib3/response.py", line 301, in read
    data = self._fp.read(amt)
  File "/usr/lib/python3.5/http/client.py", line 433, in read
    n = self.readinto(b)
  File "/usr/lib/python3.5/http/client.py", line 473, in readinto
    n = self.fp.readinto(b)
  File "/usr/lib/python3.5/socket.py", line 576, in readinto
    if e.args[0] in _blocking_errnos:
IndexError: tuple index out of range
```
