### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -3,7 +3,7 @@ guv Documentation
 
 .. note::
 
-    The documentation is currently in very active developemnt and not yet
+    The documentation is currently in very active development and not yet
     complete. Please keep checking back for updates and filing issues for
     missing sections or suggestions for enhancement.
 

--- a/guv/event.py
+++ b/guv/event.py
@@ -429,7 +429,7 @@ class AsyncResult:
     def get(self, block=True, timeout=None):
         """Return the stored value or raise the exception.
 
-        If this instance already holds a value / an exception, return / raise it immediatelly.
+        If this instance already holds a value / an exception, return / raise it immediately.
         Otherwise, block until another greenlet calls :meth:`set` or :meth:`set_exception` or
         until the optional timeout occurs.
 
@@ -463,14 +463,14 @@ class AsyncResult:
     def get_nowait(self):
         """Return the value or raise the exception without blocking.
 
-        If nothing is available, raise :class:`gevent.Timeout` immediatelly.
+        If nothing is available, raise :class:`gevent.Timeout` immediately.
         """
         return self.get(block=False)
 
     def wait(self, timeout=None):
         """Block until the instance is ready.
 
-        If this instance already holds a value / an exception, return immediatelly.
+        If this instance already holds a value / an exception, return immediately.
         Otherwise, block until another thread calls :meth:`set` or :meth:`set_exception` or
         until the optional timeout occurs.
 

--- a/guv/util/profile.py
+++ b/guv/util/profile.py
@@ -101,7 +101,7 @@ class Profile(profile_orig.Profile):
 
     def trace_dispatch_return_extend_back(self, frame, t):
         """A hack function to override error checking in parent class.  It
-        allows invalid returns (where frames weren't preveiously entered into
+        allows invalid returns (where frames weren't previously entered into
         the profiler) which can happen for all the tasklets that suddenly start
         to get monitored. This means that the time will eventually be attributed
         to a call high in the chain, when there is a tasklet switch


### PR DESCRIPTION
There are small typos in:
- docs/source/index.rst
- guv/event.py
- guv/util/profile.py

Fixes:
- Should read `immediately` rather than `immediatelly`.
- Should read `previously` rather than `preveiously`.
- Should read `development` rather than `developemnt`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md